### PR TITLE
#1 Make GitHub Actions fail Rust build on errors or warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,6 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - name: Install Rust
+      run: rustup install stable
+    - name: Add rustfmt
+      run: rustup component add rustfmt
+    - name: Check formatting
+      run: cargo fmt --all -- --check
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
 
 jobs:
   build:


### PR DESCRIPTION
# References
  - #1

# Changelog
## Added
  - Configure GitHub Actions to fail Rust build on errors, warnings, or test failures
  - Add Rustfmt check to enforce code formatting on GitHub Actions