### PR TITLE
#7 Add GitHub Actions workflow for Rust license header check

### DIFF
--- a/.github/license_header.rs
+++ b/.github/license_header.rs
@@ -1,0 +1,17 @@
+/*!
+git-brust - Rust CLI tool to visualize git branch flows
+Copyright (C) 2025  Juan Luis Leal Contreras (Kuenlun)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,0 +1,38 @@
+name: License Check
+
+on:
+  push:
+    paths:
+      - 'src/**'
+  pull_request:
+    paths:
+      - 'src/**'
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Check Rust license headers
+      run: |
+        set -euo pipefail
+
+        LICENSE_FILE=".github/license_header.rs"
+        MISSING=0
+
+        while IFS= read -r file; do
+          if ! head -n "$(wc -l < "$LICENSE_FILE")" "$file" | diff -q - "$LICENSE_FILE" > /dev/null; then
+            echo "❌ Missing or incorrect license in: $file"
+            MISSING=1
+          fi
+        done < <(find src/ -name "*.rs")
+
+        if [ $MISSING -eq 1 ]; then
+          echo "Some files are missing the correct license header."
+          exit 1
+        else
+          echo "✅ All files have the correct license header."
+        fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,20 @@
-// git-brust - Rust CLI tool to visualize git branch flows
-// Copyright (C) 2025  Juan Luis Leal Contreras (Kuenlun)
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+/*!
+git-brust - Rust CLI tool to visualize git branch flows
+Copyright (C) 2025  Juan Luis Leal Contreras (Kuenlun)
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
 
 use env_logger::Builder;
 use git2::{Commit, Oid, Repository};


### PR DESCRIPTION
# References
  - #7

# Changelog
## Added
  - Add check to ensure all Rust source code files include GPL license