### PR TITLE
#7 Check if build fails with incorrect license header

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ Copyright (C) 2025  Juan Luis Leal Contreras (Kuenlun)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
+the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,


### PR DESCRIPTION
# References
  - #7

# Description
- [x] Verify that Rust compilation fails if the license header is modified.
  - 08dd18a338058544a302ec203821acfea709b53c: https://github.com/Kuenlun/git-brust/actions/runs/17185264641/job/48753386334?pr=12